### PR TITLE
Fix componentDidUpdate while this.lib is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ export default class AnimateCC extends React.Component {
     const { error } = this.state;
     const { paused } = this.props;
 
-    if (!error) {
+    if (!error && this.lib !== undefined) {
       this.lib.tickEnabled = !paused;
     }
   }


### PR DESCRIPTION
I've noticed that sometimes `this.lib` is not set, while first `componentDidUpdate` fires.

Simple fix to make sure no errors are thrown.